### PR TITLE
Implement API for `insert`, `clear`, `all`, and inheritance

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,7 +86,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-ColumnLimit:     80
+ColumnLimit:     100
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4

--- a/_rbush/_rbush.cc
+++ b/_rbush/_rbush.cc
@@ -1,9 +1,249 @@
 #include "_rbush.h"
-
-#include <algorithm>
 #include <cmath>
 
-RBush::RBush(int max_entries) {
-    _max_entries = std::max(4, max_entries);
-    _min_entries = std::max(2, (int)std::ceil(_max_entries * 0.4));
+namespace rbush {
+
+// BBox implementation
+
+double BBox::area() const { return (max_x - min_x) * (max_y - min_y); }
+
+double BBox::margin() const { return (max_x - min_x) + (max_y - min_y); }
+
+double BBox::enlarged_area(const BBox &other) const {
+    return (std::max(other.max_x, max_x) - std::min(other.min_x, min_x)) *
+           (std::max(other.max_y, max_y) - std::min(other.min_y, min_y));
 }
+
+double BBox::intersection_area(const BBox &other) const {
+    double min_max_x = std::max(min_x, other.min_x);
+    double min_max_y = std::max(min_y, other.min_y);
+    double max_min_x = std::min(max_x, other.max_x);
+    double max_min_y = std::min(max_y, other.max_y);
+
+    return std::max(0.0, max_min_x - min_max_x) * std::max(0.0, max_min_y - min_max_y);
+}
+
+void BBox::extend(const BBox &other) {
+    min_x = std::min(min_x, other.min_x);
+    min_y = std::min(min_y, other.min_y);
+    max_x = std::max(max_x, other.max_x);
+    max_y = std::max(max_y, other.max_y);
+}
+
+// Node implementation
+
+template <typename T> BBox Node<T>::dist_bbox(int start, int end) const {
+    BBox bbox;
+    for (int i = start; i < end; i++) {
+        bbox.extend(*children[i]);
+    }
+    return bbox;
+}
+
+template <typename T> void Node<T>::calc_bbox() {
+    BBox bbox;
+    for (const auto &child : children) {
+        bbox.extend(*child);
+    }
+    min_x = bbox.min_x;
+    min_y = bbox.min_y;
+    max_x = bbox.max_x;
+    max_y = bbox.max_y;
+}
+
+// Explicit template instantiation for common types
+template struct Node<py::dict>;
+template struct Node<py::object>;
+
+// RBushBase implementation
+
+template <typename T>
+RBushBase<T>::RBushBase(size_t max_entries)
+    : _max_entries(max_entries), _min_entries(std::max<size_t>(2, max_entries / 2)) {
+    _root = std::make_unique<Node<T>>();
+    _root->height = 1;
+    _root->is_leaf = true;
+}
+
+template <typename T> void RBushBase<T>::clear() {
+    _root = std::make_unique<Node<T>>();
+    _root->height = 1;
+    _root->is_leaf = true;
+}
+
+template <typename T> void RBushBase<T>::insert(const T &item) {
+    std::unique_ptr<Node<T>> item_node = std::make_unique<Node<T>>(item);
+    BBox bbox = to_bbox(item);
+    item_node->min_x = bbox.min_x;
+    item_node->min_y = bbox.min_y;
+    item_node->max_x = bbox.max_x;
+    item_node->max_y = bbox.max_y;
+    _insert(std::move(item_node), _root->height - 1);
+}
+
+template <typename T> void RBushBase<T>::_insert(std::unique_ptr<Node<T>> item_node, int level) {
+    std::vector<std::reference_wrapper<Node<T>>> insert_path;
+
+    // find the best node for accommodating the item, saving all nodes along the path too
+    Node<T> &insert_node = _choose_subtree(*item_node, *_root, level, insert_path);
+
+    // Create a reference to the item_node before moving it
+    const BBox &item_bbox = *item_node;
+
+    // put the item into the node
+    insert_node.children.push_back(std::move(item_node));
+    insert_node.extend(item_bbox);
+
+    // split on node overflow; propagate upwards if necessary
+    while (level >= 0) {
+        if (insert_path[level].get().children.size() > _max_entries) {
+            _split(insert_path, level);
+            --level;
+        } else {
+            break;
+        }
+    }
+
+    // adjust bboxes along the insertion path
+    _adjust_parent_bboxes(item_bbox, insert_path, level);
+}
+
+template <typename T>
+Node<T> &RBushBase<T>::_choose_subtree(const BBox &bbox, Node<T> &node, int level,
+                                       std::vector<std::reference_wrapper<Node<T>>> &path) {
+    path.push_back(std::ref(node));
+
+    if (node.is_leaf || static_cast<int>(path.size()) - 1 == level) {
+        return node;
+    }
+
+    double min_enlargement = std::numeric_limits<double>::max();
+    double min_area = std::numeric_limits<double>::max();
+    std::reference_wrapper<Node<T>> chosen_node = *node.children[0];
+
+    for (const auto &child : node.children) {
+        double area = child->area();
+        double enlargement = child->enlarged_area(bbox) - area;
+
+        if (enlargement < min_enlargement || (enlargement == min_enlargement && area < min_area)) {
+            chosen_node = *child;
+        }
+
+        min_enlargement = std::min(min_enlargement, enlargement);
+        min_area = std::min(min_area, area);
+    }
+
+    return _choose_subtree(bbox, chosen_node.get(), level, path);
+}
+
+template <typename T>
+void RBushBase<T>::_split(std::vector<std::reference_wrapper<Node<T>>> &insert_path, int level) {
+    Node<T> &node = insert_path[level].get();
+    const int M = node.children.size();
+    const int m = _min_entries;
+
+    _choose_split_axis(node, m, M);
+
+    const int split_index = _choose_split_index(node, m, M);
+
+    auto new_node = std::make_unique<Node<T>>();
+    new_node->children.insert(new_node->children.end(),
+                              std::make_move_iterator(node.children.begin() + split_index),
+                              std::make_move_iterator(node.children.end()));
+    node.children.erase(node.children.begin() + split_index, node.children.end());
+
+    node.calc_bbox();
+    new_node->calc_bbox();
+
+    if (level) {
+        insert_path[level - 1].get().children.push_back(std::move(new_node));
+    } else {
+        _split_root(node, *new_node);
+    }
+}
+
+template <typename T>
+void RBushBase<T>::_adjust_parent_bboxes(const BBox &bbox,
+                                         std::vector<std::reference_wrapper<Node<T>>> &path,
+                                         int level) {
+    for (int i = level; i >= 0; --i) {
+        path[i].get().extend(bbox);
+    }
+}
+
+template <typename T> void RBushBase<T>::_split_root(Node<T> &node, Node<T> &new_node) {
+    _root = std::make_unique<Node<T>>();
+    _root->height = node.height + 1;
+    _root->is_leaf = false;
+    _root->children.push_back(std::make_unique<Node<T>>(std::move(node)));
+    _root->children.push_back(std::make_unique<Node<T>>(std::move(new_node)));
+    _root->calc_bbox();
+}
+
+template <typename T> int RBushBase<T>::_choose_split_index(Node<T> &node, int m, int M) {
+    double min_overlap = std::numeric_limits<double>::max();
+    double min_area = std::numeric_limits<double>::max();
+    int split_index = m;
+
+    for (int i = m; i <= M - m; i++) {
+        BBox bbox1 = node.dist_bbox(0, i);
+        BBox bbox2 = node.dist_bbox(i, M);
+
+        double overlap = bbox1.intersection_area(bbox2);
+        double area = bbox1.area() + bbox2.area();
+
+        if (overlap < min_overlap || (overlap == min_overlap && area < min_area)) {
+            min_overlap = overlap;
+            min_area = area;
+            split_index = i;
+        }
+    }
+
+    return split_index;
+}
+
+template <typename T> void RBushBase<T>::_choose_split_axis(Node<T> &node, int m, int M) {
+    double x_margin = _all_dist_margin(node, m, M, true);
+    double y_margin = _all_dist_margin(node, m, M, false);
+
+    if (x_margin < y_margin) {
+        std::sort(node.children.begin(), node.children.end(),
+                  [](const auto &a, const auto &b) { return BBox::compare_min_x(*a, *b); });
+    }
+}
+
+template <typename T>
+double RBushBase<T>::_all_dist_margin(Node<T> &node, int m, int M, bool compare_min_x) {
+    if (compare_min_x) {
+        std::sort(node.children.begin(), node.children.end(),
+                  [](const auto &a, const auto &b) { return BBox::compare_min_x(*a, *b); });
+    } else {
+        std::sort(node.children.begin(), node.children.end(),
+                  [](const auto &a, const auto &b) { return BBox::compare_min_y(*a, *b); });
+    }
+
+    double margin_sum = 0;
+    for (int i = 0; i < M - m + 1; i++) {
+        BBox bbox1 = node.dist_bbox(0, m + i);
+        BBox bbox2 = node.dist_bbox(m + i, M);
+        margin_sum += bbox1.margin() + bbox2.margin();
+    }
+
+    return margin_sum;
+}
+
+// RBush implementation
+
+BBox RBush::to_bbox(const py::dict &item) const {
+    double min_x = item["min_x"].cast<double>();
+    double min_y = item["min_y"].cast<double>();
+    double max_x = item["max_x"].cast<double>();
+    double max_y = item["max_y"].cast<double>();
+    return BBox(min_x, min_y, max_x, max_y);
+}
+
+// Explicit template instantiation
+template class RBushBase<py::dict>;
+template class RBushBase<py::object>;
+
+} // namespace rbush

--- a/_rbush/_rbush.cc
+++ b/_rbush/_rbush.cc
@@ -232,6 +232,35 @@ double RBushBase<T>::_all_dist_margin(Node<T> &node, int m, int M, bool compare_
     return margin_sum;
 }
 
+template <typename T> std::vector<T> RBushBase<T>::all() const {
+    std::vector<T> result;
+    _all(_root.get(), result);
+    return result;
+}
+
+template <typename T> void RBushBase<T>::_all(const Node<T> *node, std::vector<T> &result) const {
+    std::vector<const Node<T> *> nodesToSearch;
+
+    while (node) {
+        if (node->is_leaf) {
+            for (const auto &child : node->children) {
+                result.push_back(*child->data);
+            }
+        } else {
+            for (const auto &child : node->children) {
+                nodesToSearch.push_back(child.get());
+            }
+        }
+
+        if (!nodesToSearch.empty()) {
+            node = nodesToSearch.back();
+            nodesToSearch.pop_back();
+        } else {
+            node = nullptr;
+        }
+    }
+}
+
 // RBush implementation
 
 BBox RBush::to_bbox(const py::dict &item) const {

--- a/_rbush/_rbush.h
+++ b/_rbush/_rbush.h
@@ -1,13 +1,110 @@
 #ifndef _RBUSH_H_
 #define _RBUSH_H_
 
-class RBush {
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace rbush {
+
+// Bounding box structure
+struct BBox {
+    double min_x;
+    double min_y;
+    double max_x;
+    double max_y;
+
+    BBox()
+        : min_x(std::numeric_limits<double>::infinity()),
+          min_y(std::numeric_limits<double>::infinity()),
+          max_x(-std::numeric_limits<double>::infinity()),
+          max_y(-std::numeric_limits<double>::infinity()) {}
+
+    BBox(double min_x, double min_y, double max_x, double max_y)
+        : min_x(min_x), min_y(min_y), max_x(max_x), max_y(max_y) {}
+
+    double area() const;
+    double margin() const;
+    double enlarged_area(const BBox &other) const;
+    double intersection_area(const BBox &other) const;
+    void extend(const BBox &other);
+
+    static bool compare_min_x(const BBox &a, const BBox &b) { return a.min_x < b.min_x; }
+    static bool compare_min_y(const BBox &a, const BBox &b) { return a.min_y < b.min_y; }
+};
+
+// Node structure for R-tree
+template <typename T> struct Node : public BBox {
+    std::vector<std::unique_ptr<Node<T>>> children;
+    std::unique_ptr<T> data;
+    int height;
+    bool is_leaf;
+
+    Node() : BBox(), height(1), is_leaf(true) {}
+    Node(const T &item) : BBox(), data(std::make_unique<T>(item)), height(1), is_leaf(true) {}
+    Node(T &&item) : BBox(), data(std::make_unique<T>(std::move(item))), height(1), is_leaf(true) {}
+
+    BBox dist_bbox(int start, int end) const;
+    void calc_bbox();
+};
+
+// Base class for RBush
+template <typename T> class RBushBase {
 public:
-    RBush(int max_entries = 9);
+    explicit RBushBase(size_t max_entries = 9);
+    virtual ~RBushBase() = default;
+
+    RBushBase(const RBushBase &) = delete;
+    RBushBase &operator=(const RBushBase &) = delete;
+    RBushBase(RBushBase &&) = default;
+    RBushBase &operator=(RBushBase &&) = default;
+
+    void clear();
+    void insert(const T &item);
+
+    virtual BBox to_bbox(const T &item) const = 0;
 
 private:
-    int _max_entries;
-    int _min_entries;
+    size_t _max_entries;
+    size_t _min_entries;
+    std::unique_ptr<Node<T>> _root;
+
+    void _insert(std::unique_ptr<Node<T>> item_node, int level);
+    Node<T> &_choose_subtree(const BBox &bbox, Node<T> &node, int level,
+                             std::vector<std::reference_wrapper<Node<T>>> &path);
+    void _split(std::vector<std::reference_wrapper<Node<T>>> &insert_path, int level);
+    void _adjust_parent_bboxes(const BBox &bbox, std::vector<std::reference_wrapper<Node<T>>> &path,
+                               int level);
+    void _split_root(Node<T> &node, Node<T> &new_node);
+    int _choose_split_index(Node<T> &node, int m, int M);
+    void _choose_split_axis(Node<T> &node, int m, int M);
+    double _all_dist_margin(Node<T> &node, int m, int M, bool compare_min_x);
 };
+
+// Default implementation that takes a Python dictionary as input
+class RBush : public RBushBase<py::dict> {
+public:
+    using RBushBase<py::dict>::RBushBase;
+
+    BBox to_bbox(const py::dict &item) const override;
+};
+
+// Python helper class for subclassing
+class PyRBushBase : public RBushBase<py::object> {
+public:
+    using RBushBase<py::object>::RBushBase;
+
+    typedef RBushBase<py::object> BaseT;
+
+    BBox to_bbox(const py::object &item) const override {
+        PYBIND11_OVERRIDE_PURE(BBox, BaseT, to_bbox, item);
+    }
+};
+
+} // namespace rbush
 
 #endif // _RBUSH_H_

--- a/_rbush/_rbush.h
+++ b/_rbush/_rbush.h
@@ -65,6 +65,7 @@ public:
 
     void clear();
     void insert(const T &item);
+    std::vector<T> all() const;
 
     virtual BBox to_bbox(const T &item) const = 0;
 
@@ -83,6 +84,7 @@ private:
     int _choose_split_index(Node<T> &node, int m, int M);
     void _choose_split_axis(Node<T> &node, int m, int M);
     double _all_dist_margin(Node<T> &node, int m, int M, bool compare_min_x);
+    void _all(const Node<T> *node, std::vector<T> &result) const;
 };
 
 // Default implementation that takes a Python dictionary as input

--- a/_rbush/module.cc
+++ b/_rbush/module.cc
@@ -25,11 +25,13 @@ PYBIND11_MODULE(_rbush, m) {
         .def(py::init<int>(), py::arg("max_entries") = 9)
         .def("clear", &rbush::RBushBase<py::object>::clear)
         .def("insert", &rbush::RBushBase<py::object>::insert, py::arg("item"))
+        .def("all", &rbush::RBushBase<py::object>::all)
         .def("to_bbox", &rbush::RBushBase<py::object>::to_bbox, py::arg("item"));
 
     py::class_<rbush::RBush>(m, "RBush")
         .def(py::init<int>(), py::arg("max_entries") = 9)
         .def("clear", &rbush::RBushBase<py::dict>::clear)
         .def("insert", &rbush::RBushBase<py::dict>::insert, py::arg("item"))
+        .def("all", &rbush::RBushBase<py::dict>::all)
         .def("to_bbox", &rbush::RBush::to_bbox, py::arg("item"));
 }

--- a/_rbush/module.cc
+++ b/_rbush/module.cc
@@ -3,9 +3,33 @@
 
 #include "_rbush.h"
 
+namespace py = pybind11;
+
 PYBIND11_MODULE(_rbush, m) {
     m.doc() = "Internal module for py-rbush";
 
-    pybind11::class_<RBush>(m, "RBush")
-        .def(pybind11::init<int>(), pybind11::arg("max_entries") = 9);
+    py::class_<rbush::BBox>(m, "BBox")
+        .def(py::init<>())
+        .def(py::init<double, double, double, double>())
+        .def_readwrite("min_x", &rbush::BBox::min_x)
+        .def_readwrite("min_y", &rbush::BBox::min_y)
+        .def_readwrite("max_x", &rbush::BBox::max_x)
+        .def_readwrite("max_y", &rbush::BBox::max_y)
+        .def("area", &rbush::BBox::area)
+        .def("margin", &rbush::BBox::margin)
+        .def("enlarged_area", &rbush::BBox::enlarged_area)
+        .def("intersection_area", &rbush::BBox::intersection_area)
+        .def("extend", &rbush::BBox::extend);
+
+    py::class_<rbush::RBushBase<py::object>, rbush::PyRBushBase>(m, "RBushBase")
+        .def(py::init<int>(), py::arg("max_entries") = 9)
+        .def("clear", &rbush::RBushBase<py::object>::clear)
+        .def("insert", &rbush::RBushBase<py::object>::insert, py::arg("item"))
+        .def("to_bbox", &rbush::RBushBase<py::object>::to_bbox, py::arg("item"));
+
+    py::class_<rbush::RBush>(m, "RBush")
+        .def(py::init<int>(), py::arg("max_entries") = 9)
+        .def("clear", &rbush::RBushBase<py::dict>::clear)
+        .def("insert", &rbush::RBushBase<py::dict>::insert, py::arg("item"))
+        .def("to_bbox", &rbush::RBush::to_bbox, py::arg("item"));
 }

--- a/rbush/__init__.py
+++ b/rbush/__init__.py
@@ -1,6 +1,5 @@
-import _rbush
+from _rbush import BBox
+from _rbush import RBush
+from _rbush import RBushBase
 
-
-class RBush:
-    def __init__(self):
-        self._rbush = _rbush.RBush()
+__all__ = ["RBush", "RBushBase", "BBox"]

--- a/tests/test_rbush.py
+++ b/tests/test_rbush.py
@@ -1,5 +1,52 @@
-def test_rbush():
-    import rbush
+import rbush
 
+
+def test_insert():
     tree = rbush.RBush()
-    assert tree is not None
+    # generate five items
+    items = []
+    for i in range(5):
+        items.append(
+            {
+                "min_x": i,
+                "min_y": i,
+                "max_x": i + 1,
+                "max_y": i + 1,
+            }
+        )
+        tree.insert(items[i])
+    all_items = tree.all()
+
+    # the size and items should be the same
+    assert len(all_items) == 5
+    assert all(item in all_items for item in items)
+
+    # add one item into the tree
+    tree.clear()
+    item = {"min_x": 42, "min_y": 42, "max_x": 43, "max_y": 43}
+    tree.insert(item)
+    all_items = tree.all()
+
+    # the size and items should be the same
+    assert len(all_items) == 1
+    assert all_items[0] == item
+
+
+def test_inheritance():
+    class MyItem:
+        def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float) -> None:
+            self.min_x = min_x
+            self.min_y = min_y
+            self.max_x = max_x
+            self.max_y = max_y
+
+    class MyRBush(rbush.RBushBase):
+        def to_bbox(self, item: MyItem) -> rbush.BBox:
+            return rbush.BBox(item.min_x, item.min_y, item.max_x, item.max_y)
+
+    tree = MyRBush()
+    item = MyItem(0, 0, 1, 1)
+    tree.insert(item)
+    all_items = tree.all()
+    assert len(all_items) == 1
+    assert all_items[0] == item


### PR DESCRIPTION
This PR create the basic structures for RBush, and complete the API for `insert`, `clear`, `all`, and inheritance.

This PR should also resolve #7.