### PR TITLE
Fix some bugs for `insert` related features and improve the efficiency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         sudo rm /usr/bin/clang-format
         sudo ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
         curl -sSL https://install.python-poetry.org | python3 -
-        poetry install --with dev
+        poetry install -v --with dev
 
     - name: Run linters
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
-        poetry install --with dev
+        poetry install -v --with dev
 
     - name: Run tests
       run: |

--- a/_rbush/_rbush.cc
+++ b/_rbush/_rbush.cc
@@ -150,7 +150,9 @@ void RBushBase<T>::_split(std::vector<std::reference_wrapper<Node<T>>> &insert_p
     new_node->children.insert(new_node->children.end(),
                               std::make_move_iterator(node.children.begin() + split_index),
                               std::make_move_iterator(node.children.end()));
-    node.children.erase(node.children.begin() + split_index, node.children.end());
+    node.children.resize(split_index);
+    new_node->height = node.height;
+    new_node->is_leaf = node.is_leaf;
 
     node.calc_bbox();
     new_node->calc_bbox();

--- a/_rbush/_rbush.cc
+++ b/_rbush/_rbush.cc
@@ -240,33 +240,24 @@ double RBushBase<T>::_all_dist_margin(Node<T> &node, int m, int M, bool compare_
     return margin_sum;
 }
 
-template <typename T> std::vector<T> RBushBase<T>::all() const {
-    std::vector<T> result;
-    _all(_root.get(), result);
-    return result;
-}
-
-template <typename T> void RBushBase<T>::_all(const Node<T> *node, std::vector<T> &result) const {
-    std::vector<const Node<T> *> nodesToSearch;
-
-    while (node) {
-        if (node->is_leaf) {
-            for (const auto &child : node->children) {
+template <typename T> std::vector<std::reference_wrapper<T>> RBushBase<T>::all() const {
+    std::vector<std::reference_wrapper<T>> result;
+    std::vector<std::reference_wrapper<const Node<T>>> nodes_to_search;
+    nodes_to_search.push_back(std::cref(*_root));
+    while (!nodes_to_search.empty()) {
+        const Node<T> &node = nodes_to_search.back().get();
+        nodes_to_search.pop_back();
+        if (node.is_leaf) {
+            for (const auto &child : node.children) {
                 result.push_back(*child->data);
             }
         } else {
-            for (const auto &child : node->children) {
-                nodesToSearch.push_back(child.get());
+            for (const auto &child : node.children) {
+                nodes_to_search.push_back(std::cref(*child));
             }
         }
-
-        if (!nodesToSearch.empty()) {
-            node = nodesToSearch.back();
-            nodesToSearch.pop_back();
-        } else {
-            node = nullptr;
-        }
     }
+    return result;
 }
 
 // RBush implementation

--- a/_rbush/_rbush.cc
+++ b/_rbush/_rbush.cc
@@ -172,12 +172,13 @@ void RBushBase<T>::_adjust_parent_bboxes(const BBox &bbox,
 }
 
 template <typename T> void RBushBase<T>::_split_root(Node<T> &node, Node<T> &new_node) {
-    _root = std::make_unique<Node<T>>();
-    _root->height = node.height + 1;
-    _root->is_leaf = false;
-    _root->children.push_back(std::make_unique<Node<T>>(std::move(node)));
-    _root->children.push_back(std::make_unique<Node<T>>(std::move(new_node)));
-    _root->calc_bbox();
+    std::unique_ptr<Node<T>> new_root = std::make_unique<Node<T>>();
+    new_root->height = node.height + 1;
+    new_root->is_leaf = false;
+    new_root->children.push_back(std::make_unique<Node<T>>(std::move(node)));
+    new_root->children.push_back(std::make_unique<Node<T>>(std::move(new_node)));
+    new_root->calc_bbox();
+    _root = std::move(new_root);
 }
 
 template <typename T> int RBushBase<T>::_choose_split_index(Node<T> &node, int m, int M) {

--- a/_rbush/_rbush.h
+++ b/_rbush/_rbush.h
@@ -65,7 +65,7 @@ public:
 
     void clear();
     void insert(const T &item);
-    std::vector<T> all() const;
+    std::vector<std::reference_wrapper<T>> all() const;
 
     virtual BBox to_bbox(const T &item) const = 0;
 
@@ -84,7 +84,6 @@ private:
     int _choose_split_index(Node<T> &node, int m, int M);
     void _choose_split_axis(Node<T> &node, int m, int M);
     double _all_dist_margin(Node<T> &node, int m, int M, bool compare_min_x);
-    void _all(const Node<T> *node, std::vector<T> &result) const;
 };
 
 // Default implementation that takes a Python dictionary as input

--- a/tests/test_rbush.py
+++ b/tests/test_rbush.py
@@ -3,9 +3,9 @@ import rbush
 
 def test_insert():
     tree = rbush.RBush()
-    # generate five items
     items = []
-    for i in range(5):
+    # TODO: Maybe a more precise way to check all edge cases
+    for i in range(10000):
         items.append(
             {
                 "min_x": i,
@@ -18,7 +18,7 @@ def test_insert():
     all_items = tree.all()
 
     # the size and items should be the same
-    assert len(all_items) == 5
+    assert len(all_items) == 10000
     assert all(item in all_items for item in items)
 
     # add one item into the tree


### PR DESCRIPTION
The updates improve the efficiency and fix some bugs for `insert` related features, including:
- Fix the bug in `_split_root`
- Fix the bug in `_split`
- Fix the bug in `_choose_subtree`
- Refactor `all` and remove `_all`

Additionally, the test suite has been updated to ensure the correctness of these changes, but will probably need a more precise tests in the future.