### PR TITLE
Set `InsertNewlineAtEOF` to true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -130,7 +130,7 @@ IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces:    false
-InsertNewlineAtEOF: false
+InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
   Binary:          0


### PR DESCRIPTION
This pull request includes a small change to the `.clang-format` file. The change ensures that a newline is inserted at the end of the file.