### PR TITLE
Implement `serialize` and `deserialize` methods for RBush

### DIFF
--- a/_rbush/_rbush.h
+++ b/_rbush/_rbush.h
@@ -72,6 +72,8 @@ public:
     std::vector<std::reference_wrapper<T>> search(const BBox &bbox) const;
     bool collides(const BBox &bbox) const;
     std::vector<std::reference_wrapper<T>> all() const;
+    py::dict serialize() const;
+    void deserialize(const py::dict &data);
 
     virtual BBox to_bbox(const T &item) const = 0;
 
@@ -100,6 +102,8 @@ private:
     void _quick_select(std::vector<std::unique_ptr<Node<T>>> &nodes, int k, int left, int right,
                        bool compare_min_x) const;
     double _compare_node_min(const BBox &a, const BBox &b, bool compare_min_x) const;
+    py::dict _serialize_node(const Node<T> &node) const;
+    std::unique_ptr<Node<T>> _deserialize_node(const py::dict &data);
 };
 
 // Default implementation that takes a Python dictionary as input

--- a/_rbush/module.cc
+++ b/_rbush/module.cc
@@ -33,6 +33,8 @@ PYBIND11_MODULE(_rbush, m) {
         .def("search", &rbush::RBushBase<py::object>::search, py::arg("bbox"))
         .def("collides", &rbush::RBushBase<py::object>::collides, py::arg("bbox"))
         .def("all", &rbush::RBushBase<py::object>::all)
+        .def("serialize", &rbush::RBushBase<py::object>::serialize)
+        .def("deserialize", &rbush::RBushBase<py::object>::deserialize, py::arg("data"))
         .def("to_bbox", &rbush::RBushBase<py::object>::to_bbox, py::arg("item"));
 
     py::class_<rbush::RBush>(m, "RBush")
@@ -45,5 +47,7 @@ PYBIND11_MODULE(_rbush, m) {
         .def("search", &rbush::RBushBase<py::dict>::search, py::arg("bbox"))
         .def("collides", &rbush::RBushBase<py::dict>::collides, py::arg("bbox"))
         .def("all", &rbush::RBushBase<py::dict>::all)
+        .def("serialize", &rbush::RBushBase<py::dict>::serialize)
+        .def("deserialize", &rbush::RBushBase<py::dict>::deserialize, py::arg("data"))
         .def("to_bbox", &rbush::RBush::to_bbox, py::arg("item"));
 }

--- a/tests/test_rbush.py
+++ b/tests/test_rbush.py
@@ -1,257 +1,411 @@
 from __future__ import annotations
 
+import math
+
 import rbush
 
 
-def assert_list_dict_bbox_equal(a: list[dict[str, float]], b: list[list[float]]):
-    sorted_a = sorted([[item["min_x"], item["min_y"], item["max_x"], item["max_y"]] for item in a])
-    sorted_b = sorted(b)
-    assert sorted_a == sorted_b
+def default_dict_key(item: dict) -> tuple[float, float, float, float]:
+    return (item["min_x"], item["min_y"], item["max_x"], item["max_y"])
 
 
-def arr_to_dict_bbox(arr) -> dict[str, float]:
+def assert_sorted_equal(a: list, b: list, key=default_dict_key) -> None:
+    assert sorted(a, key=key) == sorted(b, key=key)
+
+
+def some_data(n: int) -> list[dict[str, float]]:
+    return [{"min_x": i, "min_y": i, "max_x": i, "max_y": i} for i in range(n)]
+
+
+def tuple_to_dict(arr: tuple[float, float, float, float]) -> dict[str, float]:
     return {"min_x": arr[0], "min_y": arr[1], "max_x": arr[2], "max_y": arr[3]}
 
 
-def arr_to_bbox(arr) -> rbush.BBox:
+def tuple_to_bbox(arr: tuple[float, float, float, float]) -> rbush.BBox:
     return rbush.BBox(arr[0], arr[1], arr[2], arr[3])
 
 
-default_data = list(
+DATA = list(
     map(
-        arr_to_dict_bbox,
+        tuple_to_dict,
         [
-            [0, 0, 0, 0],
-            [10, 10, 10, 10],
-            [20, 20, 20, 20],
-            [25, 0, 25, 0],
-            [35, 10, 35, 10],
-            [45, 20, 45, 20],
-            [0, 25, 0, 25],
-            [10, 35, 10, 35],
-            [20, 45, 20, 45],
-            [25, 25, 25, 25],
-            [35, 35, 35, 35],
-            [45, 45, 45, 45],
-            [50, 0, 50, 0],
-            [60, 10, 60, 10],
-            [70, 20, 70, 20],
-            [75, 0, 75, 0],
-            [85, 10, 85, 10],
-            [95, 20, 95, 20],
-            [50, 25, 50, 25],
-            [60, 35, 60, 35],
-            [70, 45, 70, 45],
-            [75, 25, 75, 25],
-            [85, 35, 85, 35],
-            [95, 45, 95, 45],
-            [0, 50, 0, 50],
-            [10, 60, 10, 60],
-            [20, 70, 20, 70],
-            [25, 50, 25, 50],
-            [35, 60, 35, 60],
-            [45, 70, 45, 70],
-            [0, 75, 0, 75],
-            [10, 85, 10, 85],
-            [20, 95, 20, 95],
-            [25, 75, 25, 75],
-            [35, 85, 35, 85],
-            [45, 95, 45, 95],
-            [50, 50, 50, 50],
-            [60, 60, 60, 60],
-            [70, 70, 70, 70],
-            [75, 50, 75, 50],
-            [85, 60, 85, 60],
-            [95, 70, 95, 70],
-            [50, 75, 50, 75],
-            [60, 85, 60, 85],
-            [70, 95, 70, 95],
-            [75, 75, 75, 75],
-            [85, 85, 85, 85],
-            [95, 95, 95, 95],
+            (0, 0, 0, 0),
+            (10, 10, 10, 10),
+            (20, 20, 20, 20),
+            (25, 0, 25, 0),
+            (35, 10, 35, 10),
+            (45, 20, 45, 20),
+            (0, 25, 0, 25),
+            (10, 35, 10, 35),
+            (20, 45, 20, 45),
+            (25, 25, 25, 25),
+            (35, 35, 35, 35),
+            (45, 45, 45, 45),
+            (50, 0, 50, 0),
+            (60, 10, 60, 10),
+            (70, 20, 70, 20),
+            (75, 0, 75, 0),
+            (85, 10, 85, 10),
+            (95, 20, 95, 20),
+            (50, 25, 50, 25),
+            (60, 35, 60, 35),
+            (70, 45, 70, 45),
+            (75, 25, 75, 25),
+            (85, 35, 85, 35),
+            (95, 45, 95, 45),
+            (0, 50, 0, 50),
+            (10, 60, 10, 60),
+            (20, 70, 20, 70),
+            (25, 50, 25, 50),
+            (35, 60, 35, 60),
+            (45, 70, 45, 70),
+            (0, 75, 0, 75),
+            (10, 85, 10, 85),
+            (20, 95, 20, 95),
+            (25, 75, 25, 75),
+            (35, 85, 35, 85),
+            (45, 95, 45, 95),
+            (50, 50, 50, 50),
+            (60, 60, 60, 60),
+            (70, 70, 70, 70),
+            (75, 50, 75, 50),
+            (85, 60, 85, 60),
+            (95, 70, 95, 70),
+            (50, 75, 50, 75),
+            (60, 85, 60, 85),
+            (70, 95, 70, 95),
+            (75, 75, 75, 75),
+            (85, 85, 85, 85),
+            (95, 95, 95, 95),
+        ],
+    )
+)
+
+EMPTY_DATA = list(
+    map(
+        tuple_to_dict,
+        [
+            (-math.inf, -math.inf, math.inf, math.inf),
+            (-math.inf, -math.inf, math.inf, math.inf),
+            (-math.inf, -math.inf, math.inf, math.inf),
+            (-math.inf, -math.inf, math.inf, math.inf),
+            (-math.inf, -math.inf, math.inf, math.inf),
+            (-math.inf, -math.inf, math.inf, math.inf),
         ],
     )
 )
 
 
-def test_insert():
+def test_default_max_entries():
     tree = rbush.RBush()
-    items = []
-    n = 10000
-    # TODO: Maybe a more precise way to check all edge cases
-    for i in range(n):
-        items.append(
-            {
-                "min_x": i,
-                "min_y": i,
-                "max_x": i + 1,
-                "max_y": i + 1,
-            }
-        )
-        tree.insert(items[i])
-    all_items = tree.all()
+    tree.load(some_data(9))
+    result = tree.serialize()
+    assert result["root"]["height"] == 1, result
 
-    # the size and items should be the same
-    assert len(all_items) == n
-    assert all(item in all_items for item in items)
-
-    # add one item into the tree
-    tree.clear()
-    item = {"min_x": 42, "min_y": 42, "max_x": 43, "max_y": 43}
-    tree.insert(item)
-    all_items = tree.all()
-
-    # the size and items should be the same
-    assert len(all_items) == 1
-    assert all_items[0] == item
+    tree = rbush.RBush()
+    tree.load(some_data(10))
+    result = tree.serialize()
+    assert result["root"]["height"] == 2, result
 
 
-def test_inheritance():
-    class MyItem:
-        def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float) -> None:
-            self.min_x = min_x
-            self.min_y = min_y
-            self.max_x = max_x
-            self.max_y = max_y
-
+def test_to_bbox_can_be_overridden_for_custom_data():
     class MyRBush(rbush.RBushBase):
-        def to_bbox(self, item: MyItem) -> rbush.BBox:
-            return rbush.BBox(item.min_x, item.min_y, item.max_x, item.max_y)
+        def to_bbox(self, item: dict) -> rbush.BBox:
+            return rbush.BBox(item["min_lng"], item["min_lat"], item["max_lng"], item["max_lat"])
 
-    tree = MyRBush()
-    item = MyItem(0, 0, 1, 1)
-    tree.insert(item)
-    all_items = tree.all()
-    assert len(all_items) == 1
-    assert all_items[0] == item
+    tree = MyRBush(4)
+    data = [
+        {"min_lng": -115, "min_lat": 45, "max_lng": -105, "max_lat": 55},
+        {"min_lng": 105, "min_lat": 45, "max_lng": 115, "max_lat": 55},
+        {"min_lng": 105, "min_lat": -55, "max_lng": 115, "max_lat": -45},
+        {"min_lng": -115, "min_lat": -55, "max_lng": -105, "max_lat": -45},
+    ]
+    tree.load(data)
 
+    def lat_lng_key(item: dict) -> tuple[float, float, float, float]:
+        return (item["min_lng"], item["min_lat"], item["max_lng"], item["max_lat"])
 
-def test_remove_without_fn():
-    tree = rbush.RBush()
-    items = []
-    n = 500
-    for i in range(n):
-        items.append(
-            {
-                "min_x": i,
-                "min_y": i,
-                "max_x": i + 1,
-                "max_y": i + 1,
-            }
-        )
-        tree.insert(items[i])
+    result = tree.search(rbush.BBox(-180, -90, 180, 90))
 
-    assert len(tree.all()) == n
-
-    # remove item from the tree one by one
-    for i in range(n):
-        tree.remove(items[i])
-        all_items = tree.all()
-        assert len(all_items) == n - 1 - i
-        assert all(item in all_items for item in items[i + 1 :])
-        assert items[i] not in all_items
-
-
-def test_remove_with_fn():
-    tree = rbush.RBush()
-    items = []
-    n = 500
-    for i in range(n):
-        items.append(
-            {
-                "min_x": i,
-                "min_y": i,
-                "max_x": i,
-                "max_y": i,
-                "data": i,
-            }
-        )
-        tree.insert(items[i])
-
-    assert len(tree.all()) == n
-
-    # remove item from the tree one by one
-    for i in range(n):
-        # remove without a custom compare function, this should not remove the item
-        tree.remove(items[i].copy())
-        all_items = tree.all()
-        assert len(all_items) == n - i
-        assert all(item in all_items for item in items[i:])
-        assert items[i] in all_items
-
-        # remove with a custom compare function, this should remove the item even is not the same object
-        tree.remove(items[i].copy(), lambda x, y: x["data"] == y["data"])
-        all_items = tree.all()
-        assert len(all_items) == n - 1 - i
-        assert all(item in all_items for item in items[i + 1 :])
-        assert items[i] not in all_items
-
-
-def test_search_when_found():
-    tree = rbush.RBush(4)
-    for item in default_data:
-        tree.insert(item)
-
-    result = tree.search(rbush.BBox(40, 20, 80, 70))
-
-    assert_list_dict_bbox_equal(
+    assert_sorted_equal(
         result,
         [
-            [70, 20, 70, 20],
-            [75, 25, 75, 25],
-            [45, 45, 45, 45],
-            [50, 50, 50, 50],
-            [60, 60, 60, 60],
-            [70, 70, 70, 70],
-            [45, 20, 45, 20],
-            [45, 70, 45, 70],
-            [75, 50, 75, 50],
-            [50, 25, 50, 25],
-            [60, 35, 60, 35],
-            [70, 45, 70, 45],
+            {"min_lng": -115, "min_lat": 45, "max_lng": -105, "max_lat": 55},
+            {"min_lng": 105, "min_lat": 45, "max_lng": 115, "max_lat": 55},
+            {"min_lng": 105, "min_lat": -55, "max_lng": 115, "max_lat": -45},
+            {"min_lng": -115, "min_lat": -55, "max_lng": -105, "max_lat": -45},
         ],
+        key=lat_lng_key,
+    )
+
+    result = tree.search(rbush.BBox(-180, -90, 0, 90))
+
+    assert_sorted_equal(
+        result,
+        [
+            {"min_lng": -115, "min_lat": 45, "max_lng": -105, "max_lat": 55},
+            {"min_lng": -115, "min_lat": -55, "max_lng": -105, "max_lat": -45},
+        ],
+        key=lat_lng_key,
+    )
+
+    result = tree.search(rbush.BBox(0, -90, 180, 90))
+
+    assert_sorted_equal(
+        result,
+        [
+            {"min_lng": 105, "min_lat": 45, "max_lng": 115, "max_lat": 55},
+            {"min_lng": 105, "min_lat": -55, "max_lng": 115, "max_lat": -45},
+        ],
+        key=lat_lng_key,
+    )
+
+    result = tree.search(rbush.BBox(-180, 0, 180, 90))
+
+    assert_sorted_equal(
+        result,
+        [
+            {"min_lng": -115, "min_lat": 45, "max_lng": -105, "max_lat": 55},
+            {"min_lng": 105, "min_lat": 45, "max_lng": 115, "max_lat": 55},
+        ],
+        key=lat_lng_key,
+    )
+
+    result = tree.search(rbush.BBox(-180, -90, 180, 0))
+
+    assert_sorted_equal(
+        result,
+        [
+            {"min_lng": 105, "min_lat": -55, "max_lng": 115, "max_lat": -45},
+            {"min_lng": -115, "min_lat": -55, "max_lng": -105, "max_lat": -45},
+        ],
+        key=lat_lng_key,
     )
 
 
-def test_search_when_not_found():
+def test_load_sanity():
     tree = rbush.RBush(4)
-    for item in default_data:
-        tree.insert(item)
-
-    result = tree.search(rbush.BBox(200, 200, 210, 210))
-    assert result == []
+    tree.load(DATA)
+    assert_sorted_equal(tree.all(), DATA)
 
 
-def test_collides_when_found():
+def test_load_use_standard_insert_when_low_number_of_items():
+    tree1 = rbush.RBush(8)
+    tree1.load(DATA)
+    tree1.load(DATA[:3])
+
+    tree2 = rbush.RBush(8)
+    tree2.load(DATA)
+    tree2.insert(DATA[0])
+    tree2.insert(DATA[1])
+    tree2.insert(DATA[2])
+
+    assert tree1.serialize() == tree2.serialize()
+
+
+def test_load_handle_empty_data():
+    tree = rbush.RBush()
+    tree.load([])
+
+    assert tree.serialize() == rbush.RBush().serialize()
+
+
+def test_load_hande_max_entries_plus_two_empty_bboxes():
     tree = rbush.RBush(4)
-    for item in default_data:
-        tree.insert(item)
+    tree.load(EMPTY_DATA)
+
+    assert tree.serialize()["root"]["height"] == 2
+    assert_sorted_equal(tree.all(), EMPTY_DATA)
+
+
+def test_insert_handle_max_entries_plus_two_empty_bboxes():
+    tree = rbush.RBush(4)
+
+    for data in EMPTY_DATA:
+        tree.insert(data)
+
+    assert tree.serialize()["root"]["height"] == 2
+    assert_sorted_equal(tree.all(), EMPTY_DATA)
+    assert len(tree.serialize()["root"]["children"][0]["children"]) == 4
+    assert len(tree.serialize()["root"]["children"][1]["children"]) == 2
+
+
+def test_load_properly_splits_tree_root_when_merging_trees_of_the_same_height():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+    tree.load(DATA)
+
+    assert tree.serialize()["root"]["height"] == 4
+    assert_sorted_equal(tree.all(), DATA + DATA)
+
+
+def test_load_properly_merges_data_of_smaller_or_bigger_tree_heights():
+    smaller = some_data(10)
+
+    tree1 = rbush.RBush(4)
+    tree1.load(DATA)
+    tree1.load(smaller)
+    tree2 = rbush.RBush(4)
+    tree2.load(smaller)
+    tree2.load(DATA)
+
+    assert tree1.serialize()["root"]["height"] == tree2.serialize()["root"]["height"]
+
+    assert_sorted_equal(tree1.all(), DATA + smaller)
+    assert_sorted_equal(tree2.all(), DATA + smaller)
+
+
+def test_search_finds_matching_points_in_the_tree_given_a_bbox():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+    result = tree.search(rbush.BBox(40, 20, 80, 70))
+
+    assert_sorted_equal(
+        result,
+        list(
+            map(
+                tuple_to_dict,
+                [
+                    (70, 20, 70, 20),
+                    (75, 25, 75, 25),
+                    (45, 45, 45, 45),
+                    (50, 50, 50, 50),
+                    (60, 60, 60, 60),
+                    (70, 70, 70, 70),
+                    (45, 20, 45, 20),
+                    (45, 70, 45, 70),
+                    (75, 50, 75, 50),
+                    (50, 25, 50, 25),
+                    (60, 35, 60, 35),
+                    (70, 45, 70, 45),
+                ],
+            )
+        ),
+    )
+
+
+def test_collides_returns_true_when_search_finds_matching_points():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
 
     result = tree.collides(rbush.BBox(40, 20, 80, 70))
     assert result
 
 
-def test_collides_when_not_found():
+def test_search_returns_an_empty_array_if_nothing_found():
     tree = rbush.RBush(4)
-    for item in default_data:
-        tree.insert(item)
+    tree.load(DATA)
+    result = tree.search(rbush.BBox(200, 200, 210, 210))
+    assert result == []
 
+
+def test_collides_returns_false_if_nothing_found():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
     result = tree.collides(rbush.BBox(200, 200, 210, 210))
     assert not result
 
 
-def test_load_when_empty():
-    tree = rbush.RBush()
-    tree.load(default_data)
-    all_items = tree.all()
-    assert len(all_items) == len(default_data)
-    assert all(item in all_items for item in default_data)
+def test_all_returns_all_items_in_the_tree():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+
+    assert_sorted_equal(tree.all(), DATA)
+    assert_sorted_equal(tree.search(rbush.BBox(0, 0, 100, 100)), DATA)
 
 
-def test_load_when_not_empty():
-    tree = rbush.RBush()
-    tree.insert(default_data[0])
-    tree.load(default_data[1:])
-    all_items = tree.all()
-    assert len(all_items) == len(default_data)
-    assert all(item in all_items for item in default_data)
+def test_serialize_and_deserialize_exports_and_imports_search_tree_in_JSON_format():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+    tree2 = rbush.RBush(4)
+    tree2.deserialize(tree.serialize())
+
+    assert_sorted_equal(tree.all(), tree2.all())
+
+
+def test_insert_adds_an_item_to_an_existing_tree_correctly():
+    items = list(
+        map(tuple_to_dict, [(0, 0, 0, 0), (1, 1, 1, 1), (2, 2, 2, 2), (3, 3, 3, 3), (1, 1, 2, 2)])
+    )
+
+    tree = rbush.RBush(4)
+    tree.load(items[:3])
+
+    tree.insert(items[3])
+    assert tree.serialize()["root"]["height"] == 1
+    assert_sorted_equal(tree.all(), items[:4])
+
+    tree.insert(items[4])
+    assert tree.serialize()["root"]["height"] == 2
+    assert_sorted_equal(tree.all(), items)
+
+
+def test_insert_forms_a_valid_tree_if_items_are_inserted_one_by_one():
+    tree = rbush.RBush(4)
+
+    for i in range(len(DATA)):
+        tree.insert(DATA[i])
+
+    tree2 = rbush.RBush(4)
+    tree2.load(DATA)
+
+    assert tree.serialize()["root"]["height"] - tree2.serialize()["root"]["height"] <= 1
+    assert_sorted_equal(tree.all(), tree2.all())
+
+
+def test_remove_removes_items_correctly():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+
+    length = len(DATA)
+
+    tree.remove(DATA[0])
+    tree.remove(DATA[1])
+    tree.remove(DATA[2])
+
+    tree.remove(DATA[length - 1])
+    tree.remove(DATA[length - 2])
+    tree.remove(DATA[length - 3])
+
+    assert_sorted_equal(DATA[3 : length - 3], tree.all())
+
+
+def test_remove_does_nothing_if_nothing_found():
+    tree1 = rbush.RBush(4)
+    tree1.load(DATA)
+    tree2 = rbush.RBush(4)
+    tree2.load(DATA)
+    tree2.remove(tuple_to_dict((13, 13, 13, 13)))
+
+    assert_sorted_equal(tree1.all(), tree2.all())
+
+
+def test_remove_brings_the_tree_to_a_clear_state_when_removing_everything_one_by_one():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+
+    for i in range(len(DATA)):
+        tree.remove(DATA[i])
+
+    assert tree.serialize() == rbush.RBush(4).serialize()
+
+
+def test_remove_accepts_an_equals_function():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+
+    item = {"min_x": 20, "min_y": 70, "max_x": 20, "max_y": 70, "foo": "bar"}
+    copied_item = item.copy()
+    assert id(item) != id(copied_item)
+
+    tree.insert(item)
+    tree.remove(copied_item, lambda a, b: a.get("foo") == b.get("foo"))
+
+    assert_sorted_equal(tree.all(), DATA)
+
+
+def test_clear_should_clear_all_the_data_in_the_tree():
+    tree = rbush.RBush(4)
+    tree.load(DATA)
+    tree.clear()
+    assert tree.serialize() == rbush.RBush(4).serialize()


### PR DESCRIPTION
This PR introduce methods: `serialize` and `deserialize` for import and export the state of the RBush, which should resolve #10.

Moreover, since we will have all the equivalent API in the original Javascript RBush after merging this PR, I completely refactor our tests based on the original tests of Javascript RBush.