### PR TITLE
Remove `pybind11` from dependencies and switch to git submodule

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
-        poetry install -v --with dev
+        make dev-install
 
     - name: Run benchmarks
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         sudo rm /usr/bin/clang-format
         sudo ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
         curl -sSL https://install.python-poetry.org | python3 -
-        poetry install -v --with dev
+        make dev-install
 
     - name: Run linters
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
-        poetry install -v --with dev
+        make dev-install
 
     - name: Run tests
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "pybind11"]
+	path = pybind11
+	url = ../../pybind/pybind11
+	branch = stable

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
-POETRY=poetry
-RUFF=$(POETRY) run ruff
-CLANG_FORMAT=clang-format
+POETRY := poetry
+RUFF := $(POETRY) run ruff
+PYTEST := $(POETRY) run pytest
+CLANG_FORMAT := clang-format
 
+CPP_SRC_DIR := _rbush
+CPP_SRC_FILES := $(shell find $(CPP_SRC_DIR) -name '*.cpp' -o -name '*.h' -o -name '*.cc')
+BENCHMARK_SCRIPT := benchmarks/performance.py
+TESTS_DIR := tests
 
-CPP_SRC_DIR=_rbush
-CPP_SRC_FILES=$(shell find $(CPP_SRC_DIR) -name '*.cpp' -o -name '*.h' -o -name '*.cc')
-BENCHMARK_SCRIPT=benchmarks/performance.py
+.PHONY: install dev-install lint lint-python lint-cpp fix fix-python fix-cpp test bench clean update-submodules
 
-install_deps:
+install: update-submodules
 	$(POETRY) install
+
+dev-install: update-submodules
+	$(POETRY) install -v --with dev
+
+update-submodules:
+	git submodule update --init --recursive
 
 lint: lint-python lint-cpp
 
-lint-python: install_deps
+lint-python:
 	$(RUFF) check
 	$(RUFF) format --diff
 
@@ -29,14 +38,10 @@ fix-cpp:
 	$(CLANG_FORMAT) -i $(CPP_SRC_FILES)
 
 test:
-	$(POETRY) install
-	$(POETRY) run pytest -vvv
+	$(PYTEST) $(TESTS_DIR) -vvv
 
 bench:
-	$(POETRY) install
 	$(POETRY) run python $(BENCHMARK_SCRIPT)
 
 clean:
-	rm -rf __pycache__ build dist *.so
-
-.PHONY: install_deps lint lint-python lint-cpp fix fix-python fix-cpp test bench clean
+	rm -rf __pycache__ build setup.py dist *.so

--- a/build.py
+++ b/build.py
@@ -1,4 +1,11 @@
-from pybind11.setup_helpers import Pybind11Extension
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "pybind11"))
+
+from pybind11.setup_helpers import Pybind11Extension  # noqa: E402
+
+del sys.path[-1]
 
 
 def build(setup_kwargs: dict):

--- a/poetry.lock
+++ b/poetry.lock
@@ -38,13 +38,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.1"
+version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
-    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -61,20 +61,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "pybind11"
-version = "2.13.6"
-description = "Seamless operability between C++11 and Python"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pybind11-2.13.6-py3-none-any.whl", hash = "sha256:237c41e29157b962835d356b370ededd57594a26d5894a795960f0047cb5caf5"},
-    {file = "pybind11-2.13.6.tar.gz", hash = "sha256:ba6af10348c12b24e92fa086b39cfba0eff619b61ac77c406167d813b096d39a"},
-]
-
-[package.extras]
-global = ["pybind11-global (==2.13.6)"]
 
 [[package]]
 name = "pytest"
@@ -127,16 +113,16 @@ files = [
 
 [[package]]
 name = "tomli"
-version = "2.0.2"
+version = "2.1.0"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
-    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
+    {file = "tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391"},
+    {file = "tomli-2.1.0.tar.gz", hash = "sha256:3f646cae2aec94e17d04973e4249548320197cfabdf130015d023de4b74d8ab8"},
 ]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e9239aff63154be90e8fe49a59ca3360d864095d09d18448a8b6b6bcb4f469b6"
+content-hash = "46ee0c61b4cf5124c7385e4b916e3089aa664b491e84df4e6939732e7357cc4f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pybind11 = "2.13.6"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.6.8"
@@ -46,5 +45,5 @@ script = "build.py"
 generate-setup-file = true
 
 [build-system]
-requires = ["poetry-core", "setuptools", "pybind11"]
+requires = ["poetry-core", "setuptools"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR removes `pybind11` from the dependencies in `pyproject.toml` to avoid conflicts when installing. Instead, we adopt the submodule approach, similar to [google/pytype](https://github.com/google/pytype).